### PR TITLE
Proposed: Initial Typia Validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ yarn-error.log
 src/tests/quick.ts
 test/quick.ts
 debug/quick.ts
+src/tests/quick/
 # this will be built and updated by the release bot
 # ./API.md
 

--- a/package.json
+++ b/package.json
@@ -81,6 +81,13 @@
         "./src/types/index.ts"
       ],
       "default": "./dist/types/index.js"
+    },
+    "./validate": {
+      "types": [
+        "./dist/typia/validate.d.ts",
+        "./src/typia/validate.ts"
+      ],
+      "default": "./dist/typia/validate.js"
     }
   },
   "main": "dist/index.js",
@@ -107,6 +114,7 @@
     "on:commit": "npm-run-all build test --parallel lint:fix:staged lint:types --",
     "orderbook:demo": "yarn node dist/orderbook/demo.js",
     "postinstall": "git config --local core.hooksPath .githooks || echo 'Not a git repository, did not set up git hooks'",
+    "prepare": "ts-patch install && typia patch",
     "prettier:fix": "yarn exec prettier --cache --write 'src/**/*.ts'",
     "prettier:fix:staged": "yarn exec pretty-quick --staged",
     "start:path": "yarn exec tsx --tsconfig tsconfig.tsx.json --",
@@ -128,6 +136,7 @@
     "ethers": "6.9.0",
     "isomorphic-ws": "^5.0.0",
     "tslib": "^2.6.2",
+    "typia": "^6.5.3",
     "uuid": "^9.0.1",
     "ws": "8.17.0"
   },
@@ -176,6 +185,7 @@
     "semantic-release": "^23.1.1",
     "semantic-release-slack-bot": "^4.0.2",
     "slackify-markdown": "^4.4.0",
+    "ts-patch": "^3.2.1",
     "tsx": "^4.10.2",
     "typedoc": "0.25.13",
     "typedoc-plugin-extras": "^3.0.0",
@@ -183,7 +193,7 @@
     "typedoc-plugin-merge-modules": "^5.1.0",
     "typedoc-plugin-missing-exports": "^2.2.0",
     "typedoc-theme-category-nav": "^0.0.3",
-    "typescript": "5.4.5",
+    "typescript": "5.5.2",
     "typescript-eslint": "^7.9.0"
   },
   "optionalDependencies": {

--- a/src/typia/validate.ts
+++ b/src/typia/validate.ts
@@ -1,0 +1,125 @@
+import typia from 'typia';
+
+import type * as types from '#types/rest/endpoints/index';
+
+/*
+  [Typia](https://typia.io)
+
+  These are used for testing validation and will generate optimized validation functions
+  at compile time where each fn returns an object which indicates if the input matches
+  the type definition with information on errors if it does not.
+
+  {
+    success: false,
+    errors: [
+      { path: '$input[0].quoteBalance', expected: 'string', value: 2 },
+      {
+        path: '$input[9].positions[0].markPrice',
+        expected: 'string',
+        value: 2
+      }
+    ],
+    data: undefined
+  }
+
+  @Note : Detailed validation such as "uuidv1" checking is possible but not implemented at this
+          time
+
+  @see [Special Tags](https://typia.io/docs/validators/tags/)
+*/
+
+export const validateRestResponseAssociateWallet =
+  typia.createValidateEquals<types.RestResponseAssociateWallet>();
+
+export const validateRestResponseAuthorizePayout =
+  typia.createValidateEquals<types.RestResponseAuthorizePayout>();
+
+export const validateRestResponseCancelOrders =
+  typia.createValidateEquals<types.RestResponseCancelOrders>();
+
+export const validateRestResponseGetAuthenticationToken =
+  typia.createValidateEquals<types.RestResponseGetAuthenticationToken>();
+
+export const validateRestResponseGetCandles =
+  typia.createValidateEquals<types.RestResponseGetCandles>();
+
+// export const validateRestResponseGetDeposit =
+//   typia.createValidateEquals<types.RestResponseGetDeposit>();
+
+export const validateRestResponseGetDeposits =
+  typia.createValidateEquals<types.RestResponseGetDeposits>();
+
+export const validateRestResponseGetExchange =
+  typia.createValidateEquals<types.RestResponseGetExchange>();
+
+// export const validateRestResponseGetFill =
+//   typia.createValidateEquals<types.RestResponseGetFill>();
+
+export const validateRestResponseGetFills =
+  typia.createValidateEquals<types.RestResponseGetFills>();
+
+export const validateRestResponseGetFundingPayments =
+  typia.createValidateEquals<types.RestResponseGetFundingPayments>();
+
+export const validateRestResponseGetFundingRates =
+  typia.createValidateEquals<types.RestResponseGetFundingRates>();
+
+export const validateRestResponseGetGasFees =
+  typia.createValidateEquals<types.RestResponseGetGasFees>();
+
+export const validateRestResponseGetHistoricalPnL =
+  typia.createValidateEquals<types.RestResponseGetHistoricalPnL>();
+
+export const validateRestResponseGetLeverage =
+  typia.createValidateEquals<types.RestResponseGetLeverage>();
+
+export const validateRestResponseGetLiquidations =
+  typia.createValidateEquals<types.RestResponseGetLiquidations>();
+
+// export const validateRestResponseGetMarketMakerRewardsEpoch =
+//   typia.createValidateEquals<types.RestResponseGetMarketMakerRewardsEpoch>();
+
+export const validateRestResponseGetMarketMakerRewardsEpochs =
+  typia.createValidateEquals<types.RestResponseGetMarketMakerRewardsEpochs>();
+
+export const validateRestResponseGetMarkets =
+  typia.createValidateEquals<types.RestResponseGetMarkets>();
+
+export const validateRestResponseGetOrders =
+  typia.createValidateEquals<types.RestResponseGetOrders>();
+
+export const validateRestResponseGetOrderBookLevel1 =
+  typia.createValidateEquals<types.RestResponseGetOrderBookLevel1>();
+
+export const validateRestResponseGetOrderBookLevel2 =
+  typia.createValidateEquals<types.RestResponseGetOrderBookLevel2>();
+
+export const validateRestResponseGetPayouts =
+  typia.createValidateEquals<types.RestResponseGetPayouts>();
+
+// export const validateRestResponseGetPing =
+// typia.createValidateEquals<types.RestResponseGetPing>();
+
+export const validateRestResponseGetPositions =
+  typia.createValidateEquals<types.RestResponseGetPositions>();
+
+export const validateRestResponseGetTickers =
+  typia.createValidateEquals<types.RestResponseGetTickers>();
+
+export const validateRestResponseGetTrades =
+  typia.createValidateEquals<types.RestResponseGetTrades>();
+
+export const validateRestResponseGetWallets =
+  typia.createValidateEquals<types.RestResponseGetWallets>();
+
+// export const validateRestResponseGetWithdrawal =
+// typia.createValidateEquals<types.RestResponseGetWithdrawal>();
+
+export const validateRestResponseGetWithdrawals =
+  typia.createValidateEquals<types.RestResponseGetWithdrawals>();
+
+export const validateRestResponseSetLeverage =
+  typia.createValidateEquals<types.RestResponseSetLeverage>();
+
+export const validateRestResponseWithdrawFunds =
+  typia.createValidateEquals<types.RestResponseWithdrawFunds>();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,10 @@
     "declaration": true,
     "declarationMap": true,
     "importHelpers": true,
-    "lib": ["dom", "esnext"],
+    "lib": [
+      "dom",
+      "esnext"
+    ],
     "resolvePackageJsonImports": true,
     "resolvePackageJsonExports": true,
     "outDir": "dist",
@@ -16,10 +19,21 @@
     "useUnknownInCatchVariables": false,
     // does not cut off type hints as early
     "noErrorTruncation": true,
-    "verbatimModuleSyntax": false
+    "verbatimModuleSyntax": false,
     // needed to trick yarn run:quick to work as tsx
     // otherwise doesnt understand import/export maps
+    "plugins": [
+      {
+        "transform": "typia/lib/transform"
+      }
+    ],
+    "strictNullChecks": true,
+    "strict": true
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -626,6 +626,7 @@ __metadata:
     semantic-release: "npm:^23.1.1"
     semantic-release-slack-bot: "npm:^4.0.2"
     slackify-markdown: "npm:^4.4.0"
+    ts-patch: "npm:^3.2.1"
     tslib: "npm:^2.6.2"
     tsx: "npm:^4.10.2"
     typedoc: "npm:0.25.13"
@@ -634,8 +635,9 @@ __metadata:
     typedoc-plugin-merge-modules: "npm:^5.1.0"
     typedoc-plugin-missing-exports: "npm:^2.2.0"
     typedoc-theme-category-nav: "npm:^0.0.3"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.2"
     typescript-eslint: "npm:^7.9.0"
+    typia: "npm:^6.5.3"
     uuid: "npm:^9.0.1"
     ws: "npm:8.17.0"
   dependenciesMeta:
@@ -1187,6 +1189,13 @@ __metadata:
     "@qiwi/substrate-types": "npm:2.1.0"
     tslib: "npm:^2.6.2"
   checksum: 10c0/be6c9345e264cc73e19deb8699cf84ba5c9915363534c45e94f8fa14b27d280b82c88ab1bc84b353d18fe0af122aa5ea129a7aae16178673e8ff4d60e5a69a00
+  languageName: node
+  linkType: hard
+
+"@samchon/openapi@npm:^0.4.2":
+  version: 0.4.2
+  resolution: "@samchon/openapi@npm:0.4.2"
+  checksum: 10c0/cba2e6b57f0ccf5bf3a7e3beb52dc7a14051cd3b6a6b6e84be74e9fec5db66914c0c7a54e0246a4784828579fdf8b9c9403c62417b6895dda994c67997fffc6e
   languageName: node
   linkType: hard
 
@@ -2224,6 +2233,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"array-timsort@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "array-timsort@npm:1.0.3"
+  checksum: 10c0/bd3a1707b621947265c89867e67c9102b9b9f4c50f5b3974220112290d8b60d26ce60595edec5deed3325207b759d70b758bed3cd310b5ddadb835657ffb6d12
+  languageName: node
+  linkType: hard
+
 "array-union@npm:^1.0.1":
   version: 1.0.2
   resolution: "array-union@npm:1.0.2"
@@ -2700,7 +2716,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.1.1":
+"chalk@npm:^4.1.1, chalk@npm:^4.1.2":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:
@@ -3041,6 +3057,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"commander@npm:^10.0.0":
+  version: 10.0.1
+  resolution: "commander@npm:10.0.1"
+  checksum: 10c0/53f33d8927758a911094adadda4b2cbac111a5b377d8706700587650fd8f45b0bbe336de4b5c3fe47fd61f420a3d9bd452b6e0e6e5600a7e74d7bf0174f6efe3
+  languageName: node
+  linkType: hard
+
+"comment-json@npm:^4.2.3":
+  version: 4.2.4
+  resolution: "comment-json@npm:4.2.4"
+  dependencies:
+    array-timsort: "npm:^1.0.3"
+    core-util-is: "npm:^1.0.3"
+    esprima: "npm:^4.0.1"
+    has-own-prop: "npm:^2.0.0"
+    repeat-string: "npm:^1.6.1"
+  checksum: 10c0/a30cfea0dbac85f1894ac2add0e21add7d7f0f0a577285e464246704043d83f1b94f8eda868a59079a97538cf0c65be70e2a2c1c4d8afae7bd8329dc75a6f7de
+  languageName: node
+  linkType: hard
+
 "commitizen@npm:^4.0.3":
   version: 4.1.2
   resolution: "commitizen@npm:4.1.2"
@@ -3251,6 +3287,13 @@ __metadata:
   version: 0.1.1
   resolution: "copy-descriptor@npm:0.1.1"
   checksum: 10c0/161f6760b7348c941007a83df180588fe2f1283e0867cc027182734e0f26134e6cc02de09aa24a95dc267b2e2025b55659eef76c8019df27bc2d883033690181
+  languageName: node
+  linkType: hard
+
+"core-util-is@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "core-util-is@npm:1.0.3"
+  checksum: 10c0/90a0e40abbddfd7618f8ccd63a74d88deea94e77d0e8dbbea059fa7ebebb8fbb4e2909667fe26f3a467073de1a542ebe6ae4c73a73745ac5833786759cd906c9
   languageName: node
   linkType: hard
 
@@ -3619,6 +3662,13 @@ __metadata:
   dependencies:
     is-obj: "npm:^2.0.0"
   checksum: 10c0/2431adeab57984e51b99766fb4a0fecae9e24f92f231cb3b2e317c0de49cbc91dff9846ae7a96f2be336be32fb93deed84a5e3d30c440a9e4b46beca92fb0b2c
+  languageName: node
+  linkType: hard
+
+"drange@npm:^1.0.2":
+  version: 1.1.1
+  resolution: "drange@npm:1.1.1"
+  checksum: 10c0/d63f364467be64d766d2dae10ee7e4f305fa50375f910c7525fb5983cab326ad0f1a4a3abdf2379e7d7949c0011a291114d5c6c238970a940a08a6ccba02f7b3
   languageName: node
   linkType: hard
 
@@ -4129,6 +4179,16 @@ __metadata:
     acorn-jsx: "npm:^5.3.2"
     eslint-visitor-keys: "npm:^3.4.1"
   checksum: 10c0/1a2e9b4699b715347f62330bcc76aee224390c28bb02b31a3752e9d07549c473f5f986720483c6469cf3cfb3c9d05df612ffc69eb1ee94b54b739e67de9bb460
+  languageName: node
+  linkType: hard
+
+"esprima@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "esprima@npm:4.0.1"
+  bin:
+    esparse: ./bin/esparse.js
+    esvalidate: ./bin/esvalidate.js
+  checksum: 10c0/ad4bab9ead0808cf56501750fd9d3fb276f6b105f987707d059005d57e182d18a7c9ec7f3a01794ebddcca676773e42ca48a32d67a250c9d35e009ca613caba3
   languageName: node
   linkType: hard
 
@@ -5307,6 +5367,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"global-prefix@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "global-prefix@npm:3.0.0"
+  dependencies:
+    ini: "npm:^1.3.5"
+    kind-of: "npm:^6.0.2"
+    which: "npm:^1.3.1"
+  checksum: 10c0/510f489fb68d1cc7060f276541709a0ee6d41356ef852de48f7906c648ac223082a1cc8fce86725ca6c0e032bcdc1189ae77b4744a624b29c34a9d0ece498269
+  languageName: node
+  linkType: hard
+
 "globals@npm:^13.19.0":
   version: 13.24.0
   resolution: "globals@npm:13.24.0"
@@ -5451,6 +5522,13 @@ __metadata:
   version: 4.0.0
   resolution: "has-flag@npm:4.0.0"
   checksum: 10c0/2e789c61b7888d66993e14e8331449e525ef42aac53c627cc53d1c3334e768bcb6abdc4f5f0de1478a25beec6f0bd62c7549058b7ac53e924040d4f301f02fd1
+  languageName: node
+  linkType: hard
+
+"has-own-prop@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "has-own-prop@npm:2.0.0"
+  checksum: 10c0/2745497283d80228b5c5fbb8c63ab1029e604bce7db8d4b36255e427b3695b2153dc978b176674d0dd2a23f132809e04d7ef41fefc0ab85870a5caa918c5c0d9
   languageName: node
   linkType: hard
 
@@ -5888,7 +5966,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ini@npm:^1.3.4, ini@npm:~1.3.0":
+"ini@npm:^1.3.4, ini@npm:^1.3.5, ini@npm:~1.3.0":
   version: 1.3.8
   resolution: "ini@npm:1.3.8"
   checksum: 10c0/ec93838d2328b619532e4f1ff05df7909760b6f66d9c9e2ded11e5c1897d6f2f9980c54dd638f88654b00919ce31e827040631eab0a3969e4d1abefa0719516a
@@ -5951,6 +6029,29 @@ __metadata:
     through: "npm:^2.3.6"
     wrap-ansi: "npm:^7.0.0"
   checksum: 10c0/e3e64e10f5daeeb8f770f1310acceb4aab593c10d693e7676ecd4a5b023d5b865b484fec7ead516e5e394db70eff687ef85459f75890f11a99ceadc0f4adce18
+  languageName: node
+  linkType: hard
+
+"inquirer@npm:^8.2.5":
+  version: 8.2.6
+  resolution: "inquirer@npm:8.2.6"
+  dependencies:
+    ansi-escapes: "npm:^4.2.1"
+    chalk: "npm:^4.1.1"
+    cli-cursor: "npm:^3.1.0"
+    cli-width: "npm:^3.0.0"
+    external-editor: "npm:^3.0.3"
+    figures: "npm:^3.0.0"
+    lodash: "npm:^4.17.21"
+    mute-stream: "npm:0.0.8"
+    ora: "npm:^5.4.1"
+    run-async: "npm:^2.4.0"
+    rxjs: "npm:^7.5.5"
+    string-width: "npm:^4.1.0"
+    strip-ansi: "npm:^6.0.0"
+    through: "npm:^2.3.6"
+    wrap-ansi: "npm:^6.0.1"
+  checksum: 10c0/eb5724de1778265323f3a68c80acfa899378cb43c24cdcb58661386500e5696b6b0b6c700e046b7aa767fe7b4823c6f04e6ddc268173e3f84116112529016296
   languageName: node
   linkType: hard
 
@@ -9462,6 +9563,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"randexp@npm:^0.5.3":
+  version: 0.5.3
+  resolution: "randexp@npm:0.5.3"
+  dependencies:
+    drange: "npm:^1.0.2"
+    ret: "npm:^0.2.0"
+  checksum: 10c0/44ad4e6e7661c090939e062916ccf1477de27eb2b91dfa8c113de9f3116ddf2016ac090323d5d2fa0947c3ff8e9b24798ee5e25cb2c37f22df2e72cda56232b6
+  languageName: node
+  linkType: hard
+
 "randombytes@npm:^2.1.0":
   version: 2.1.0
   resolution: "randombytes@npm:2.1.0"
@@ -9785,7 +9896,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.22.4":
+"resolve@npm:^1.22.2, resolve@npm:^1.22.4":
   version: 1.22.8
   resolution: "resolve@npm:1.22.8"
   dependencies:
@@ -9807,7 +9918,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@npm%3A^1.22.4#optional!builtin<compat/resolve>":
+"resolve@patch:resolve@npm%3A^1.22.2#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.4#optional!builtin<compat/resolve>":
   version: 1.22.8
   resolution: "resolve@patch:resolve@npm%3A1.22.8#optional!builtin<compat/resolve>::version=1.22.8&hash=c3c19d"
   dependencies:
@@ -9847,6 +9958,13 @@ __metadata:
     onetime: "npm:^5.1.0"
     signal-exit: "npm:^3.0.2"
   checksum: 10c0/6f7da8c5e422ac26aa38354870b1afac09963572cf2879443540449068cb43476e9cbccf6f8de3e0171e0d6f7f533c2bc1a0a008003c9a525bbc098e89041318
+  languageName: node
+  linkType: hard
+
+"ret@npm:^0.2.0":
+  version: 0.2.2
+  resolution: "ret@npm:0.2.2"
+  checksum: 10c0/1a41e543913cda851abb1dae4852efa97bb693ce58fde3b51cc1cae94e2599dd70b91ad6268a4a07fc238305be06fed91723ef6d08863c48a0d02e0a74b943cd
   languageName: node
   linkType: hard
 
@@ -11166,6 +11284,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ts-patch@npm:^3.2.1":
+  version: 3.2.1
+  resolution: "ts-patch@npm:3.2.1"
+  dependencies:
+    chalk: "npm:^4.1.2"
+    global-prefix: "npm:^3.0.0"
+    minimist: "npm:^1.2.8"
+    resolve: "npm:^1.22.2"
+    semver: "npm:^7.5.4"
+    strip-ansi: "npm:^6.0.1"
+  bin:
+    ts-patch: bin/ts-patch.js
+    tspc: bin/tspc.js
+  checksum: 10c0/c214e0218f905c6445830821d400280c9b127fa41f2984bbad59c1f19eda7b6a0529457af7bc6d80fdfa38289207d5b5e2f40912c33758a243ca2064ed0aa137
+  languageName: node
+  linkType: hard
+
 "tslib@npm:2.4.0":
   version: 2.4.0
   resolution: "tslib@npm:2.4.0"
@@ -11381,23 +11516,40 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:5.4.5":
-  version: 5.4.5
-  resolution: "typescript@npm:5.4.5"
+"typescript@npm:5.5.2":
+  version: 5.5.2
+  resolution: "typescript@npm:5.5.2"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/2954022ada340fd3d6a9e2b8e534f65d57c92d5f3989a263754a78aba549f7e6529acc1921913560a4b816c46dce7df4a4d29f9f11a3dc0d4213bb76d043251e
+  checksum: 10c0/8ca39b27b5f9bd7f32db795045933ab5247897660627251e8254180b792a395bf061ea7231947d5d7ffa5cb4cc771970fd4ef543275f9b559f08c9325cccfce3
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A5.4.5#optional!builtin<compat/typescript>":
-  version: 5.4.5
-  resolution: "typescript@patch:typescript@npm%3A5.4.5#optional!builtin<compat/typescript>::version=5.4.5&hash=5adc0c"
+"typescript@patch:typescript@npm%3A5.5.2#optional!builtin<compat/typescript>":
+  version: 5.5.2
+  resolution: "typescript@patch:typescript@npm%3A5.5.2#optional!builtin<compat/typescript>::version=5.5.2&hash=b45daf"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/db2ad2a16ca829f50427eeb1da155e7a45e598eec7b086d8b4e8ba44e5a235f758e606d681c66992230d3fc3b8995865e5fd0b22a2c95486d0b3200f83072ec9
+  checksum: 10c0/6721ac8933a70c252d7b640b345792e103d881811ff660355617c1836526dbb71c2044e2e77a8823fb3570b469f33276875a4cab6d3c4de4ae7d7ee1c3074ae4
+  languageName: node
+  linkType: hard
+
+"typia@npm:^6.5.3":
+  version: 6.5.3
+  resolution: "typia@npm:6.5.3"
+  dependencies:
+    "@samchon/openapi": "npm:^0.4.2"
+    commander: "npm:^10.0.0"
+    comment-json: "npm:^4.2.3"
+    inquirer: "npm:^8.2.5"
+    randexp: "npm:^0.5.3"
+  peerDependencies:
+    typescript: ">=4.8.0 <5.6.0"
+  bin:
+    typia: lib/executable/typia.js
+  checksum: 10c0/179182e17aa24d947aaa9a976a6ac12462f072ec5ae63cafec7eaf0e036bd3b02700e097b2d6cee791c202113f2e32025b076111dab7e43354d6caeed30c803c
   languageName: node
   linkType: hard
 
@@ -11752,7 +11904,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"which@npm:^1.2.14, which@npm:^1.2.9":
+"which@npm:^1.2.14, which@npm:^1.2.9, which@npm:^1.3.1":
   version: 1.3.1
   resolution: "which@npm:1.3.1"
   dependencies:
@@ -11823,6 +11975,17 @@ __metadata:
     string-width: "npm:^4.1.0"
     strip-ansi: "npm:^6.0.0"
   checksum: 10c0/d15fc12c11e4cbc4044a552129ebc75ee3f57aa9c1958373a4db0292d72282f54373b536103987a4a7594db1ef6a4f10acf92978f79b98c49306a4b58c77d4da
+  languageName: node
+  linkType: hard
+
+"wrap-ansi@npm:^6.0.1":
+  version: 6.2.0
+  resolution: "wrap-ansi@npm:6.2.0"
+  dependencies:
+    ansi-styles: "npm:^4.0.0"
+    string-width: "npm:^4.1.0"
+    strip-ansi: "npm:^6.0.0"
+  checksum: 10c0/baad244e6e33335ea24e86e51868fe6823626e3a3c88d9a6674642afff1d34d9a154c917e74af8d845fd25d170c4ea9cf69a47133c3f3656e1252b3d462d9f6c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
We have a few options for handling validation to aid in testing.  Typia is the simplest as it is an AOC validation library which generates validation functions based on the Typescript Types.  These can be enhanced to validate against specific patterns or values like `uuidv1` as well.

- Another valid option is to use `Zod`, however Zod generally expects things to be backwards (you create the validator and then infer the type from that so we would likely need to reconsider a few areas to implement).
  - There are tools which use the compiler to automatically generate zod validations -- but typia is much more performant and capable.

> Typia is also capable of generating OpenAPI specifications so we could provide this as an added tool for using things like PostMan, Swagger, or generators for other languages in the future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a comprehensive set of validation functions for various REST API responses, enhancing type safety and ensuring correct data formatting.
	- Added validation capabilities for endpoints related to wallet associations, payout authorizations, order cancellations, and more.

- **Bug Fixes**
	- Improved error handling in validation functions to provide detailed feedback on input mismatches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->